### PR TITLE
fixed aging in WL

### DIFF
--- a/BlockManagers/wear_leveling_strategy.cpp
+++ b/BlockManagers/wear_leveling_strategy.cpp
@@ -90,7 +90,7 @@ void Wear_Leveling_Strategy::register_erase_completion(Event const& event) {
 	int age = data.age - 1;
 	if (age_distribution.count(age - 1) == 1) {
 		age_distribution[age - 1]--;
-		age_distribution[age]--;
+		age_distribution[age]++;
 		if (age_distribution[age - 1] == 0) {
 			age_distribution.erase(age - 1);
 		}


### PR DESCRIPTION
In  _BlockManagers/wear_leveling_strategy.cpp_  when the age of a to be erased block increases by 1, (	data.age++;), the entry in age_distribution must be increased by 1 too.
As you can see below, the age of blocks decreases in each step and reach to a big negative number.
![image](https://cloud.githubusercontent.com/assets/3257322/20833909/56f82bba-b8a7-11e6-89d2-2c50fb5dd972.png)
![image](https://cloud.githubusercontent.com/assets/3257322/20833914/5a25018c-b8a7-11e6-97fb-e70d4019c0c3.png)
